### PR TITLE
nvdiffrast: init at 0.3.0

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -42,6 +42,7 @@ in
       albumentations
       cppimport
       instant-ngp
+      nvdiffrast
       opensfm
       ezy-expecttest
       imviz pyimgui dearpygui

--- a/pkgs/nvdiffrast.nix
+++ b/pkgs/nvdiffrast.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, torch
+, tensorflow
+, imageio
+, ninja
+, cudatoolkit
+}:
+
+let
+  pname = "nvdiffrast";
+  version = "0.3.0";
+in
+buildPythonPackage {
+  inherit pname version;
+  src = fetchFromGitHub {
+    owner = "NVLabs";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-erMac+xt5f3dMWu8c3rlpUV/uixUYOimHexwaNq0Uu0=";
+  };
+  postPatch = ''
+  '';
+  buildInputs = [
+  ];
+  propagatedBuildInputs = [
+    numpy
+  ];
+  checkInputs = [
+    torch
+    tensorflow
+  ];
+  passthru.extras-require.all = [
+    torch
+    imageio
+    ninja
+    cudatoolkit
+  ];
+  meta = {
+    maintainers = [ lib.maintainers.SomeoneSerge ];
+    license = {
+      fullName = "Nvidia Source Code License (1-Way Commercial)";
+      free = true;
+    };
+    description = "Modular Primitives for High-Performance Differentiable Rendering";
+    homepage = "https://nvlabs.github.io/nvdiffrast/";
+    platforms = lib.platforms.unix;
+  };
+}

--- a/python-overrides.nix
+++ b/python-overrides.nix
@@ -19,6 +19,8 @@
 
   ezy-expecttest = python-final.callPackage ./pkgs/ezy-expecttest.nix { };
 
+  nvdiffrast = python-final.callPackage ./pkgs/nvdiffrast.nix { };
+
   opensfm = python-final.callPackage ./pkgs/opensfm { };
   kornia = python-final.callPackage ./pkgs/kornia.nix { };
   gpytorch = python-final.callPackage ./pkgs/gpytorch.nix { };


### PR DESCRIPTION
...currently not precompiling the CUDA modules `->` `cpp_extension` builds them at runtime; suprisingly, without running into any permission errors; at least on NixOS