### PR TITLE
alpaca-cpp: unstable-2023-03-30 -> 9116ae9


### DIFF
--- a/pkgs/alpaca-cpp.nix
+++ b/pkgs/alpaca-cpp.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
   pname = "alpaca-cpp";
-  version = "unstable-2023-03-30";
+  version = "9116ae9";
 
   src = fetchFromGitHub {
     owner = "antimatter15";


### PR DESCRIPTION
Diff: https://github.com/antimatter15/alpaca.cpp/compare/81bd894...9116ae9
