### PR TITLE
instant-ngp: unstable-2022-04-07 -> continuous


### DIFF
--- a/pkgs/instant-ngp/default.nix
+++ b/pkgs/instant-ngp/default.nix
@@ -24,7 +24,7 @@
 
 let
   pname = "instant-ngp";
-  version = "unstable-2022-04-07";
+  version = "continuous";
 
   cudatoolkit = symlinkJoin {
     name = "cudatoolkit-root";


### PR DESCRIPTION
Diff: https://github.com/NVlabs/instant-ngp/compare/16212cd9e0c80d8345896a864f5af7054723a1d0...continuous
