### PR TITLE
llama-cpp: master-b8ad1b6 -> master-6e91a1b


### DIFF
--- a/pkgs/llama.cpp/default.nix
+++ b/pkgs/llama.cpp/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   pname = "llama-cpp";
-  version = "master-b8ad1b6";
+  version = "master-6e91a1b";
 
   src = fetchFromGitHub {
     owner = "ggerganov";


### PR DESCRIPTION
Diff: https://github.com/ggerganov/llama.cpp/compare/master-ed3c680...master-6e91a1b
