### PR TITLE
geomstats: 2.6.0 -> 2.7.0


### DIFF
--- a/pkgs/geomstats.nix
+++ b/pkgs/geomstats.nix
@@ -12,7 +12,7 @@
 
 let
   pname = "geomstats";
-  version = "2.5.0";
+  version = "2.6.0";
 in
 buildPythonPackage {
   inherit pname version;
@@ -21,7 +21,7 @@ buildPythonPackage {
     owner = "geomstats";
     repo = pname;
     rev = "${version}";
-    hash = "sha256-3FP4pgLMjd1qHcWSkwV8bG+tlxMU3LwKCPfgqOjJfpg=";
+    hash = "sha256-A/NU5kEWhVL3FA3WAGVeMGrPuqbB6Cw5cTbzMzleHjM=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Diff: https://github.com/geomstats/geomstats/compare/2.6.0...2.7.0
