### PR TITLE
stable-diffusion-webui: init at this is ludicrous

### DIFF
--- a/python-packages/by-name/ba/basicsr/package.nix
+++ b/python-packages/by-name/ba/basicsr/package.nix
@@ -1,0 +1,72 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, addict
+, cython_3
+, future
+, lmdb
+, numpy
+, opencv4
+, pillow
+, pythonRelaxDepsHook
+, pyyaml
+, requests
+, scikit-image
+, scipy
+, tensorboard
+, torch
+, torchvision
+, tqdm
+, yapf
+}:
+
+buildPythonPackage rec {
+  pname = "basicsr";
+  version = "1.4.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "XPixelGroup";
+    repo = "BasicSR";
+    rev = "v${version}";
+    hash = "sha256-UfwwwF0h0c5oPeGhj0w5Zw2edjPNoQWNG4pKHBwMU2I=";
+  };
+
+  nativeBuildInputs = [
+    cython_3
+    pythonRelaxDepsHook
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    addict
+    future
+    lmdb
+    numpy
+    opencv4
+    pillow
+    pyyaml
+    requests
+    scikit-image
+    scipy
+    tensorboard
+    torch
+    torchvision
+    tqdm
+    yapf
+  ];
+
+  pythonRemoveDeps = [ "tb-nightly" ];
+
+  pythonImportsCheck = [ "basicsr" ];
+
+  meta = with lib; {
+    description = "Open Source Image and Video Restoration Toolbox for Super-resolution, Denoise, Deblurring, etc. Currently, it includes EDSR, RCAN, SRResNet, SRGAN, ESRGAN, EDVR, BasicVSR, SwinIR, ECBSR, etc. Also support StyleGAN2, DFDNet";
+    homepage = "https://github.com/XPixelGroup/BasicSR";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/python-packages/by-name/bl/blendmodes/package.nix
+++ b/python-packages/by-name/bl/blendmodes/package.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, aenum
+, deprecation
+, numpy
+, pillow
+}:
+
+buildPythonPackage rec {
+  pname = "blendmodes";
+  version = "2023";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "FHPythonUtils";
+    repo = "BlendModes";
+    rev = version;
+    hash = "sha256-eLYd4QQbJ7t82vbbDM1hundfHZX37wkPd5Pm2hjrqQI=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aenum
+    deprecation
+    numpy
+    pillow
+  ];
+
+  pythonImportsCheck = [ "blendmodes" ];
+
+  meta = with lib; {
+    description = "Use this module to apply a number of blending modes to a background and foreground image";
+    homepage = "https://github.com/FHPythonUtils/BlendModes";
+    changelog = "https://github.com/FHPythonUtils/BlendModes/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/python-packages/by-name/co/codeformer/package.nix
+++ b/python-packages/by-name/co/codeformer/package.nix
@@ -1,0 +1,110 @@
+{ lib
+, fetchFromGitHub
+, basicsr
+, buildPythonPackage
+, prefix-python-modules
+, nixpkgs-pytools
+, codeformer
+, lpips
+, opencv4
+, setuptools
+, torch
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "codeformer";
+  version = "unstable-2023-07-23";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sczhou";
+    repo = "CodeFormer";
+    rev = "8392d0334956108ab53d9439c4b9fc9c4af0d66d";
+    hash = "sha256-yfQuscYnDwtv7RleWOvGZdzwDAGRawqPrVX9wZq12lY=";
+  };
+
+  postPatch = ''
+    rm -r basicsr
+    prefix-python-modules . --prefix $pname --exclude-glob 'web-demos*'
+    python-rewrite-imports --path . --replace basicsr codeformer_basicsr
+    cp ${./pyproject.toml} pyproject.toml
+  '';
+
+  nativeBuildInputs = [
+    prefix-python-modules
+    nixpkgs-pytools
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    passthru.basicsr
+    opencv4
+    torch
+  ];
+
+  pythonImportsCheck = [
+    "codeformer.inference_codeformer"
+  ];
+
+  # codeformer vendors a patched copy of basicsr, but also vendors the setup.py
+  # and some adds invalid imports there.
+  passthru.basicsr = basicsr.overridePythonAttrs (oldAttrs: {
+    pname = "codeformer-basicsr";
+
+    # TODO: finalAttrs
+    src = codeformer.src;
+
+    # TODO: discard; we probably should just keep codeformer's basicsr in the
+    # closure, and not the original
+    prePatch = ''
+      cd basicsr
+
+      mv __init__.py init.py
+
+      echo '__version__ = "0.0.0+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' >> version.py
+      echo '__gitsha__ = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' >> version.py
+      echo >> README.md
+      echo >> requirements.txt
+
+      substituteInPlace \
+        archs/__init__.py \
+        models/__init__.py \
+        data/__init__.py \
+        --replace \
+          "import_module(f'basicsr." \
+          "import_module(f'codeformer_basicsr."
+
+      substituteInPlace setup.py \
+        --replace \
+          "name='basicsr'" \
+          "name='codeformer_basicsr'"
+        
+
+      prefix-python-modules . --prefix codeformer_basicsr  \
+        --rename-external basicsr codeformer_basicsr "**"
+      mv codeformer_basicsr/init.py codeformer_basicsr/__init__.py
+      mv codeformer_basicsr/setup.py ./
+
+      mkdir basicsr
+      mv VERSION basicsr/
+    '';
+    nativeBuildInputs = oldAttrs.nativeBuildInputs or [ ] ++ [
+      prefix-python-modules
+    ];
+    propagatedBuildInputs = oldAttrs.propagatedBuildInputs or [ ] ++ [
+      lpips
+    ];
+    pythonImportsCheck = [ "codeformer_basicsr" ];
+  });
+
+  meta = with lib; {
+    description = "NeurIPS 2022] Towards Robust Blind Face Restoration with Codebook Lookup Transformer";
+    homepage = "https://github.com/sczhou/CodeFormer";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+    mainProgram = "codeformer";
+    platforms = platforms.all;
+  };
+}

--- a/python-packages/by-name/co/codeformer/pyproject.toml
+++ b/python-packages/by-name/co/codeformer/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [ "setuptools" ]
+
+[project]
+name = "codeformer"
+version = "0.0.0"
+
+[tool.setuptools.packages.find]
+include = [ "codeformer*" ]

--- a/python-packages/by-name/co/comfy-ui/0001-main.py-add-an-entrypoint.patch
+++ b/python-packages/by-name/co/comfy-ui/0001-main.py-add-an-entrypoint.patch
@@ -1,7 +1,7 @@
 From 7311ede52d8a1c79049b81e9614c8c7e4537a556 Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Mon, 6 Nov 2023 20:23:23 +0000
-Subject: [PATCH 1/5] main.py: add an entrypoint
+Subject: [PATCH 1/6] main.py: add an entrypoint
 
 ---
  main.py | 6 +++++-

--- a/python-packages/by-name/co/comfy-ui/0001-main.py-add-an-entrypoint.patch
+++ b/python-packages/by-name/co/comfy-ui/0001-main.py-add-an-entrypoint.patch
@@ -1,7 +1,7 @@
 From 7311ede52d8a1c79049b81e9614c8c7e4537a556 Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Mon, 6 Nov 2023 20:23:23 +0000
-Subject: [PATCH 1/6] main.py: add an entrypoint
+Subject: [PATCH 1/8] main.py: add an entrypoint
 
 ---
  main.py | 6 +++++-

--- a/python-packages/by-name/co/comfy-ui/0002-comfy.model_management-fallback-to-cpu.patch
+++ b/python-packages/by-name/co/comfy-ui/0002-comfy.model_management-fallback-to-cpu.patch
@@ -1,7 +1,7 @@
 From 62ac2e1df6c7cda2e443ca6572795ecc1eba667c Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Mon, 6 Nov 2023 20:29:36 +0000
-Subject: [PATCH 2/6] comfy.model_management: fallback to cpu
+Subject: [PATCH 2/8] comfy.model_management: fallback to cpu
 
 This is because --cpu users may want to use pytorch compiled without cuda support
 ---

--- a/python-packages/by-name/co/comfy-ui/0002-comfy.model_management-fallback-to-cpu.patch
+++ b/python-packages/by-name/co/comfy-ui/0002-comfy.model_management-fallback-to-cpu.patch
@@ -1,7 +1,7 @@
 From 62ac2e1df6c7cda2e443ca6572795ecc1eba667c Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Mon, 6 Nov 2023 20:29:36 +0000
-Subject: [PATCH 2/5] comfy.model_management: fallback to cpu
+Subject: [PATCH 2/6] comfy.model_management: fallback to cpu
 
 This is because --cpu users may want to use pytorch compiled without cuda support
 ---

--- a/python-packages/by-name/co/comfy-ui/0003-tests-inference-guard-cuda-references.patch
+++ b/python-packages/by-name/co/comfy-ui/0003-tests-inference-guard-cuda-references.patch
@@ -1,7 +1,7 @@
 From 85d472a0c68a78c90d1b6b8b504eeddef5124e63 Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Mon, 6 Nov 2023 20:55:23 +0000
-Subject: [PATCH 3/5] tests/inference: guard cuda references
+Subject: [PATCH 3/6] tests/inference: guard cuda references
 
 ---
  tests/inference/test_inference.py | 6 ++++--

--- a/python-packages/by-name/co/comfy-ui/0003-tests-inference-guard-cuda-references.patch
+++ b/python-packages/by-name/co/comfy-ui/0003-tests-inference-guard-cuda-references.patch
@@ -1,7 +1,7 @@
 From 85d472a0c68a78c90d1b6b8b504eeddef5124e63 Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Mon, 6 Nov 2023 20:55:23 +0000
-Subject: [PATCH 3/6] tests/inference: guard cuda references
+Subject: [PATCH 3/8] tests/inference: guard cuda references
 
 ---
  tests/inference/test_inference.py | 6 ++++--

--- a/python-packages/by-name/co/comfy-ui/0004-cli_args-add-extra-path.patch
+++ b/python-packages/by-name/co/comfy-ui/0004-cli_args-add-extra-path.patch
@@ -1,7 +1,7 @@
 From 3d7b9fe76d8004309770d5121960329dcdba149a Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Tue, 7 Nov 2023 00:04:22 +0000
-Subject: [PATCH 4/6] cli_args: add --extra-path
+Subject: [PATCH 4/8] cli_args: add --extra-path
 
 For extending search paths ad hoc, as required for splayed installations
 ---

--- a/python-packages/by-name/co/comfy-ui/0004-cli_args-add-extra-path.patch
+++ b/python-packages/by-name/co/comfy-ui/0004-cli_args-add-extra-path.patch
@@ -1,7 +1,7 @@
-From daa90b12665f709ae42157494ab080739b17d4c4 Mon Sep 17 00:00:00 2001
+From 3d7b9fe76d8004309770d5121960329dcdba149a Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Tue, 7 Nov 2023 00:04:22 +0000
-Subject: [PATCH 4/5] cli_args: add --extra-path
+Subject: [PATCH 4/6] cli_args: add --extra-path
 
 For extending search paths ad hoc, as required for splayed installations
 ---
@@ -22,14 +22,14 @@ index e79b89c..2e2e823 100644
  if comfy.options.args_parsing:
      args = parser.parse_args()
 diff --git a/main.py b/main.py
-index 426359e..6e5c303 100644
+index 426359e..3206c03 100644
 --- a/main.py
 +++ b/main.py
 @@ -148,6 +148,9 @@ def main():
          folder_paths.set_temp_directory(temp_dir)
      cleanup_temp()
  
-+    for kind, path in args.extra_paths or []:
++    for kind, path in args.extra_path or []:
 +        folder_paths.add_model_folder_path(kind, path)
 +
      loop = asyncio.new_event_loop()

--- a/python-packages/by-name/co/comfy-ui/0005-folder_paths-allow-overriding-base_path.patch
+++ b/python-packages/by-name/co/comfy-ui/0005-folder_paths-allow-overriding-base_path.patch
@@ -1,7 +1,7 @@
-From b63525a667dc04c413f4d0aec247667eaf30ed9e Mon Sep 17 00:00:00 2001
+From e965b1cf03db8f43da665b09839c7ab8d00a3c25 Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Tue, 7 Nov 2023 00:29:17 +0000
-Subject: [PATCH 5/5] folder_paths: allow overriding base_path
+Subject: [PATCH 5/6] folder_paths: allow overriding base_path
 
 ...while re-using the relative paths listed in folder_paths.py
 ---

--- a/python-packages/by-name/co/comfy-ui/0005-folder_paths-allow-overriding-base_path.patch
+++ b/python-packages/by-name/co/comfy-ui/0005-folder_paths-allow-overriding-base_path.patch
@@ -1,7 +1,7 @@
 From e965b1cf03db8f43da665b09839c7ab8d00a3c25 Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Tue, 7 Nov 2023 00:29:17 +0000
-Subject: [PATCH 5/6] folder_paths: allow overriding base_path
+Subject: [PATCH 5/8] folder_paths: allow overriding base_path
 
 ...while re-using the relative paths listed in folder_paths.py
 ---

--- a/python-packages/by-name/co/comfy-ui/0006-folder_paths-in-temp-out-dirs-respect-overrides.patch
+++ b/python-packages/by-name/co/comfy-ui/0006-folder_paths-in-temp-out-dirs-respect-overrides.patch
@@ -1,7 +1,7 @@
 From 26b746e8d9f1f2a69dacd1a06fc4fea5874be61a Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Tue, 7 Nov 2023 15:36:19 +0000
-Subject: [PATCH 6/6] folder_paths: in/temp/out dirs: respect overrides
+Subject: [PATCH 6/8] folder_paths: in/temp/out dirs: respect overrides
 
 ...in particular, cli_args and COMFY_BASE_PATH
 

--- a/python-packages/by-name/co/comfy-ui/0006-folder_paths-in-temp-out-dirs-respect-overrides.patch
+++ b/python-packages/by-name/co/comfy-ui/0006-folder_paths-in-temp-out-dirs-respect-overrides.patch
@@ -1,0 +1,40 @@
+From 26b746e8d9f1f2a69dacd1a06fc4fea5874be61a Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Tue, 7 Nov 2023 15:36:19 +0000
+Subject: [PATCH 6/6] folder_paths: in/temp/out dirs: respect overrides
+
+...in particular, cli_args and COMFY_BASE_PATH
+
+Both are necessary, because cli_args are apparently disabled depending
+on enable_parsing()
+---
+ folder_paths.py | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/folder_paths.py b/folder_paths.py
+index df81250..b4e3948 100644
+--- a/folder_paths.py
++++ b/folder_paths.py
+@@ -1,5 +1,6 @@
+ import os
+ import time
++from comfy.cli_args import args
+ 
+ supported_pt_extensions = set(['.ckpt', '.pt', '.bin', '.pth', '.safetensors'])
+ 
+@@ -31,9 +32,9 @@ folder_names_and_paths["hypernetworks"] = ([os.path.join(models_dir, "hypernetwo
+ 
+ folder_names_and_paths["classifiers"] = ([os.path.join(models_dir, "classifiers")], {""})
+ 
+-output_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "output")
+-temp_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "temp")
+-input_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "input")
++output_directory = args.output_directory or os.path.join(base_path, "output")
++temp_directory = args.temp_directory or os.path.join(base_path, "temp")
++input_directory = args.input_directory or os.path.join(base_path, "input")
+ 
+ filename_list_cache = {}
+ 
+-- 
+2.42.0
+

--- a/python-packages/by-name/co/comfy-ui/0007-cli_args-make-it-possible-to-see-the-final-args.patch
+++ b/python-packages/by-name/co/comfy-ui/0007-cli_args-make-it-possible-to-see-the-final-args.patch
@@ -1,0 +1,34 @@
+From bcdcd5c43d0952a400073fba961870822e52f310 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Sat, 18 Nov 2023 07:11:19 +0000
+Subject: [PATCH 7/8] cli_args: make it possible to see the final args
+
+---
+ comfy/cli_args.py | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/comfy/cli_args.py b/comfy/cli_args.py
+index 2e2e823..9e76ea5 100644
+--- a/comfy/cli_args.py
++++ b/comfy/cli_args.py
+@@ -1,6 +1,8 @@
+ import argparse
+-import enum
+ import comfy.options
++import enum
++import pprint
++import sys
+ 
+ class EnumAction(argparse.Action):
+     """
+@@ -110,3 +112,7 @@ if args.windows_standalone_build:
+ 
+ if args.disable_auto_launch:
+     args.auto_launch = False
++
++# The args are parsed at import-time and non-deterministically ignored,
++# but at least we could peek at what exactly we end up using
++pprint.pprint({"args_parsing": comfy.options.args_parsing, "args": args}, sys.stderr)
+-- 
+2.42.0
+

--- a/python-packages/by-name/co/comfy-ui/0008-options-os.environ-to-prevent-the-entrypoint-from-ig.patch
+++ b/python-packages/by-name/co/comfy-ui/0008-options-os.environ-to-prevent-the-entrypoint-from-ig.patch
@@ -1,0 +1,26 @@
+From cea1f13f7177d65427f47c28c6bb1fbb83bc40a2 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Sat, 18 Nov 2023 07:22:11 +0000
+Subject: [PATCH 8/8] options: os.environ to prevent the entrypoint from
+ ignoring the args
+
+---
+ comfy/options.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/comfy/options.py b/comfy/options.py
+index f7f8af4..adbdc16 100644
+--- a/comfy/options.py
++++ b/comfy/options.py
+@@ -1,5 +1,7 @@
++import os
++
++args_parsing = "COMFY_FORCE_ARGS" in os.environ
+ 
+-args_parsing = False
+ 
+ def enable_args_parsing(enable=True):
+     global args_parsing
+-- 
+2.42.0
+

--- a/python-packages/by-name/co/comfy-ui/package.nix
+++ b/python-packages/by-name/co/comfy-ui/package.nix
@@ -1,7 +1,7 @@
 { lib
 , accelerate
 , aiohttp
-, buildPythonApplication
+, buildPythonPackage
 , einops
 , fetchFromGitHub
 , pillow
@@ -22,7 +22,7 @@
 , transformers
 }:
 
-buildPythonApplication rec {
+buildPythonPackage rec {
   pname = "comfy-ui";
   version = "unstable-2023-11-06";
   pyproject = true;
@@ -42,6 +42,7 @@ buildPythonApplication rec {
     ./0003-tests-inference-guard-cuda-references.patch
     ./0004-cli_args-add-extra-path.patch
     ./0005-folder_paths-allow-overriding-base_path.patch
+    ./0006-folder_paths-in-temp-out-dirs-respect-overrides.patch
   ];
 
   postPatch = ''

--- a/python-packages/by-name/co/comfy-ui/package.nix
+++ b/python-packages/by-name/co/comfy-ui/package.nix
@@ -70,6 +70,8 @@ buildPythonPackage rec {
     ./0004-cli_args-add-extra-path.patch
     ./0005-folder_paths-allow-overriding-base_path.patch
     ./0006-folder_paths-in-temp-out-dirs-respect-overrides.patch
+    ./0007-cli_args-make-it-possible-to-see-the-final-args.patch
+    ./0008-options-os.environ-to-prevent-the-entrypoint-from-ig.patch
   ];
 
   postPatch = ''
@@ -158,10 +160,12 @@ buildPythonPackage rec {
 
     makeWrapper $out/bin/comfy-ui $out/bin/comfy-ui-relpaths \
       --add-flags '--extra-model-paths-config "${relativeModelPaths}"' \
-      --set-default COMFY_BASE_PATH .
+      --set-default COMFY_BASE_PATH . \
+      --set-default COMFY_FORCE_ARGS 1
   '';
 
   meta = with lib; {
+    broken = true; # The build works, but the runtime is untested
     description = "The most powerful and modular stable diffusion GUI with a graph/nodes interface";
     homepage = "https://github.com/comfyanonymous/ComfyUI";
     license = licenses.gpl3Only;

--- a/python-packages/by-name/fa/facexlib/package.nix
+++ b/python-packages/by-name/fa/facexlib/package.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, cython_3
+, filterpy
+, numba
+, numpy
+, opencv4
+, pillow
+, scipy
+, torch
+, torchvision
+, tqdm
+}:
+
+buildPythonPackage rec {
+  pname = "facexlib";
+  version = "0.2.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xinntao";
+    repo = "facexlib";
+    rev = "v${version}";
+    hash = "sha256-2mqjGtrOigOxyGFEFZBK2/SqEhIv5cbrQU/bYDVje7Q=";
+  };
+
+  nativeBuildInputs = [
+    cython_3
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    filterpy
+    numba
+    numpy
+    opencv4
+    pillow
+    scipy
+    torch
+    torchvision
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "facexlib" ];
+
+  meta = with lib; {
+    description = "FaceXlib aims at providing ready-to-use face-related functions based on current STOA open-source methods";
+    homepage = "https://github.com/xinntao/facexlib";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/python-packages/by-name/gf/gfpgan/package.nix
+++ b/python-packages/by-name/gf/gfpgan/package.nix
@@ -1,0 +1,62 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, basicsr
+, cython_3
+, facexlib
+, lmdb
+, numpy
+, opencv4
+, pyyaml
+, scipy
+, tensorboard
+, torch
+, torchvision
+, tqdm
+, yapf
+}:
+
+buildPythonPackage rec {
+  pname = "gfpgan";
+  version = "1.3.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "TencentARC";
+    repo = "GFPGAN";
+    rev = "v${version}";
+    hash = "sha256-frJ3hSniHvCSEPB1awJsXLuUxYRRMbV9GS4GSPKwXOg=";
+  };
+
+  nativeBuildInputs = [
+    cython_3
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    basicsr
+    facexlib
+    lmdb
+    numpy
+    opencv4
+    pyyaml
+    scipy
+    tensorboard
+    torch
+    torchvision
+    tqdm
+    yapf
+  ];
+
+  pythonImportsCheck = [ "gfpgan" ];
+
+  meta = with lib; {
+    description = "GFPGAN aims at developing Practical Algorithms for Real-world Face Restoration";
+    homepage = "https://github.com/TencentARC/GFPGAN";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/python-packages/by-name/k-/k-diffusion/package.nix
+++ b/python-packages/by-name/k-/k-diffusion/package.nix
@@ -1,0 +1,79 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, accelerate
+, clean-fid
+, clip-anytorch
+, dctorch
+, einops
+, jsonmerge
+, kornia
+, pillow
+, prefix-python-modules
+, safetensors
+, scikit-image
+, scipy
+, torch
+, torchdiffeq
+, torchsde
+, torchvision
+, tqdm
+, wandb
+}:
+
+buildPythonPackage rec {
+  pname = "k-diffusion";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "crowsonkb";
+    repo = "k-diffusion";
+    rev = "v${version}";
+    hash = "sha256-ef4NhViHQcV+4T+GXpg+Qev5IC0Cid+XWE3sFVx7w4w=";
+  };
+
+  postPatch = ''
+    prefix-python-modules . --prefix k_diffusion --exclude-glob 'setup*'
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+    prefix-python-modules
+  ];
+
+  propagatedBuildInputs = [
+    accelerate
+    clean-fid
+    clip-anytorch
+    dctorch
+    einops
+    jsonmerge
+    kornia
+    pillow
+    safetensors
+    scikit-image
+    scipy
+    torch
+    torchdiffeq
+    torchsde
+    torchvision
+    tqdm
+    wandb
+  ];
+
+  pythonImportsCheck = [
+    "k_diffusion"
+    "k_diffusion.layers"
+  ];
+
+  meta = with lib; {
+    description = "Karras et al. (2022) diffusion models for PyTorch";
+    homepage = "https://github.com/crowsonkb/k-diffusion";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/python-packages/by-name/op/open-clip-torch/package.nix
+++ b/python-packages/by-name/op/open-clip-torch/package.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, ftfy
+, huggingface-hub
+, prefix-python-modules
+, protobuf
+, regex
+, sentencepiece
+, timm
+, torch
+, torchvision
+, tqdm
+}:
+
+buildPythonPackage rec {
+  pname = "open-clip-torch";
+  version = "2.23.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mlfoundations";
+    repo = "open_clip";
+    rev = "v${version}";
+    hash = "sha256-Txm47Tc4KMbz1i2mROT+IYbgS1Y0yHK80xY0YldgBFQ=";
+  };
+
+  postPatch = ''
+    prefix-python-modules src/ --prefix open_clip
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+    prefix-python-modules
+  ];
+
+  propagatedBuildInputs = [
+    ftfy
+    huggingface-hub
+    protobuf
+    regex
+    sentencepiece
+    timm
+    torch
+    torchvision
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "open_clip" "open_clip.training" ];
+
+  meta = with lib; {
+    description = "An open source implementation of CLIP";
+    homepage = "https://github.com/mlfoundations/open_clip";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/python-packages/by-name/pr/prefix-python-modules/prefix_python_modules.py
+++ b/python-packages/by-name/pr/prefix-python-modules/prefix_python_modules.py
@@ -56,10 +56,10 @@ def convert_to_packages(project_root, exclude_globs: List[str]):
     try:
         for f in python_files:
             rel_path = Path(f.path)
-            if rel_path.parent == Path("."):
-                continue
-            path = project_root / rel_path.parent / "__init__.py"
-            path.touch()
+            while rel_path.parent != Path("."):
+                path = project_root / rel_path.parent / "__init__.py"
+                path.touch()
+                rel_path = rel_path.parent
     finally:
         project.close()
 
@@ -150,6 +150,8 @@ def prefix_modules(
 
         toplevel_files = sorted(set(Path(p.path).parts[0] for p in python_files))
         toplevel_module_names = [name.removesuffix(".py") for name in toplevel_files]
+
+        assert all("-" not in x for x in toplevel_module_names), toplevel_module_names
 
         new_package = project.get_folder(prefix)
         if not new_package.exists():

--- a/python-packages/by-name/py/pycocoevalcap/package.nix
+++ b/python-packages/by-name/py/pycocoevalcap/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "pycocoevalcap";
+  version = "1.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "salaniz";
+    repo = "pycocoevalcap";
+    rev = "v${version}";
+    hash = "sha256-LcMcxRF8IVu7t05GXVXKzsFBxdP+LllfuV3vCGNdYvk=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  pythonImportsCheck = [
+    "pycocoevalcap.eval"
+  ];
+
+  meta = with lib; {
+    description = "Python 3 support for the MS COCO caption evaluation tools";
+    homepage = "https://github.com/salaniz/pycocoevalcap";
+    license = licenses.bsd2WithViews;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/python-packages/by-name/re/realesrgan/package.nix
+++ b/python-packages/by-name/re/realesrgan/package.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, basicsr
+, cython_3
+, facexlib
+, gfpgan
+, numpy
+, opencv4
+, pillow
+, torch
+, torchvision
+, tqdm
+}:
+
+buildPythonPackage rec {
+  pname = "realesrgan";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xinntao";
+    repo = "Real-ESRGAN";
+    rev = "v${version}";
+    hash = "sha256-pdOYDOAnKKt+5M6dD8ksTbFoA8EwjGUZVx+UGpxCF6c=";
+  };
+
+  nativeBuildInputs = [
+    cython_3
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    basicsr
+    facexlib
+    gfpgan
+    numpy
+    opencv4
+    pillow
+    torch
+    torchvision
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "realesrgan" ];
+
+  meta = with lib; {
+    description = "Real-ESRGAN aims at developing Practical Algorithms for General Image/Video Restoration";
+    homepage = "https://github.com/xinntao/Real-ESRGAN";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/python-packages/by-name/sa/salesforce-blip/package.nix
+++ b/python-packages/by-name/sa/salesforce-blip/package.nix
@@ -1,0 +1,73 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, fairscale
+, opencv4
+, prefix-python-modules
+, pycocoevalcap
+, pycocotools
+, ruamel-yaml
+, setuptools
+, timm
+, torch
+, torchvision
+, transformers
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "blip";
+  version = "unstable-2022-09-20";
+  pyproject = true;
+  pyprojectToml = ./pyproject.toml;
+
+  src = fetchFromGitHub {
+    owner = "salesforce";
+    repo = "BLIP";
+    rev = "3a29b7410476bf5f2ba0955827390eb6ea1f4f9d";
+    hash = "sha256-WX+raOYWrDdODF+AwKtDMep5+2o1Xyr4cKW02OwA9EU=";
+  };
+
+  postPatch = ''
+    prefix-python-modules . --prefix $pname \
+      --rename-external ruamel_yaml ruamel "**"
+    cp $pyprojectToml pyproject.toml
+  '';
+
+  nativeBuildInputs = [
+    prefix-python-modules
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    fairscale
+    opencv4
+    pycocoevalcap
+    pycocotools
+    ruamel-yaml
+    timm
+    torch
+    torchvision
+    transformers
+  ];
+
+  pythonImportsCheck = [
+    "blip.models.blip"
+    "blip.models.vit"
+    "blip.transform.randaugment"
+    # Depends on https://pypi.org/project/cog/?
+    # "blip.predict"
+    "blip.pretrain"
+    "blip.train_retrieval"
+  ];
+
+  meta = with lib; {
+    description = "PyTorch code for BLIP: Bootstrapping Language-Image Pre-training for Unified Vision-Language Understanding and Generation";
+    homepage = "https://github.com/salesforce/BLIP";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+    mainProgram = "blip";
+    platforms = platforms.all;
+  };
+}

--- a/python-packages/by-name/sa/salesforce-blip/pyproject.toml
+++ b/python-packages/by-name/sa/salesforce-blip/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [ "setuptools" ]
+
+[project]
+name = "blip"
+version = "0.0.0"
+
+[tool.setuptools.packages.find]
+include = [ "blip*" ]
+

--- a/python-packages/by-name/st/stability-ai-generative-models/package.nix
+++ b/python-packages/by-name/st/stability-ai-generative-models/package.nix
@@ -1,0 +1,106 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, hatchling
+, einops
+, fairscale
+, fire
+, fsspec
+, invisible-watermark
+, kornia
+, matplotlib
+, natsort
+, numpy
+, omegaconf
+, onnx
+, open-clip-torch
+, opencv4
+, pandas
+, pillow
+, pudb
+, pytorch-lightning
+, pyyaml
+, scipy
+, streamlit
+, tensorboardx
+, timm
+, tokenizers
+, torch
+, torchaudio
+, torchdata
+, torchmetrics
+, torchvision
+, tqdm
+, transformers
+, triton
+, urllib3
+, wandb
+, webdataset
+, xformers
+}:
+
+buildPythonPackage rec {
+  pname = "stability-ai-generative-models";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Stability-AI";
+    repo = "generative-models";
+    rev = version;
+    hash = "sha256-qaZeaCfOO4vWFZZAyqNpJbTttJy17GQ5+DM05yTLktA=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    pytorch-lightning
+    # clip @ git+https://github.com/openai/CLIP.git
+    einops
+    fairscale
+    fire
+    fsspec
+    invisible-watermark
+    kornia
+    matplotlib
+    natsort
+    numpy
+    omegaconf
+    onnx
+    open-clip-torch
+    opencv4
+    pandas
+    pillow
+    pudb
+    pytorch-lightning
+    pyyaml
+    scipy
+    streamlit
+    tensorboardx
+    timm
+    tokenizers
+    torch
+    torchaudio
+    torchdata
+    torchmetrics
+    torchvision
+    tqdm
+    transformers
+    triton
+    urllib3
+    wandb
+    webdataset
+    xformers
+  ];
+
+  pythonImportsCheck = [ "sgm" ];
+
+  meta = with lib; {
+    description = "Generative Models by Stability AI";
+    homepage = "https://github.com/Stability-AI/generative-models.git";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/python-packages/by-name/st/stability-ai-sd/package.nix
+++ b/python-packages/by-name/st/stability-ai-sd/package.nix
@@ -15,9 +15,9 @@
 , opencv4
 , prefix-python-modules
 , pudb
+, python
 , pytorch-lightning
 , streamlit
-
   # , streamlit-drawable-canvas
 , test-tube
 , torchmetrics
@@ -75,6 +75,10 @@ buildPythonPackage rec {
 
   # Needs `npm build`
   pythonRemoveDeps = [ "streamlit-drawable-canvas" ];
+
+  postInstall = ''
+    cp -r configs $out/${python.sitePackages}/ldm/
+  '';
 
   pythonImportsCheck = [
     "ldm"

--- a/python-packages/by-name/st/stability-ai-sd/package.nix
+++ b/python-packages/by-name/st/stability-ai-sd/package.nix
@@ -1,0 +1,90 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, albumentations
+, einops
+, gradio
+, imageio
+, imageio-ffmpeg
+, invisible-watermark
+, kornia
+, omegaconf
+, open-clip-torch
+, opencv4
+, prefix-python-modules
+, pudb
+, pytorch-lightning
+, streamlit
+
+  # , streamlit-drawable-canvas
+, test-tube
+, torchmetrics
+, transformers
+, webdataset
+}:
+
+buildPythonPackage rec {
+  pname = "stability-ai-sd";
+  version = "unstable-2023-03-25";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Stability-AI";
+    repo = "stablediffusion";
+    rev = "cf1d67a6fd5ea1aa600c4df58e5b47da45f6bdbf";
+    hash = "sha256-yEtrz/JTq53JDI4NZI26KsD8LAgiViwiNaB2i1CBs/I=";
+  };
+
+  postPatch = ''
+    substituteInPlace ldm/models/diffusion/ddpm.py \
+      --replace \
+        pytorch_lightning.utilities.distributed \
+        pytorch_lightning.utilities.rank_zero
+
+    prefix-python-modules . --prefix ldm --exclude-glob 'setup.py'
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+    prefix-python-modules
+  ];
+
+  propagatedBuildInputs = [
+    albumentations
+    einops
+    gradio
+    imageio
+    imageio-ffmpeg
+    invisible-watermark
+    kornia
+    omegaconf
+    open-clip-torch
+    opencv4
+    pudb
+    pytorch-lightning
+    streamlit
+    # streamlit-drawable-canvas
+    test-tube
+    torchmetrics
+    transformers
+    webdataset
+  ];
+
+  # Needs `npm build`
+  pythonRemoveDeps = [ "streamlit-drawable-canvas" ];
+
+  pythonImportsCheck = [
+    "ldm"
+    "ldm.models.diffusion.ddpm"
+  ];
+
+  meta = with lib; {
+    description = "High-Resolution Image Synthesis with Latent Diffusion Models";
+    homepage = "https://github.com/Stability-AI/stablediffusion";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/python-packages/by-name/st/stability-ai-sd/package.nix
+++ b/python-packages/by-name/st/stability-ai-sd/package.nix
@@ -83,6 +83,9 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "ldm"
     "ldm.models.diffusion.ddpm"
+
+    # Cf. postPatch
+    "pytorch_lightning.utilities.rank_zero"
   ];
 
   meta = with lib; {

--- a/python-packages/by-name/st/stable-diffusion-webui/0001-modules.paths-try-PYTHONPATH-before-custom-search-pa.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0001-modules.paths-try-PYTHONPATH-before-custom-search-pa.patch
@@ -1,7 +1,7 @@
 From 1855d31a212cfac8011ac015b1c7a3d799d5e850 Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Tue, 7 Nov 2023 17:20:06 +0000
-Subject: [PATCH 1/2] modules.paths: try PYTHONPATH before custom search paths
+Subject: [PATCH 1/5] modules.paths: try PYTHONPATH before custom search paths
 
 ---
  modules/paths.py | 22 ++++++++++++++++++++++

--- a/python-packages/by-name/st/stable-diffusion-webui/0001-modules.paths-try-PYTHONPATH-before-custom-search-pa.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0001-modules.paths-try-PYTHONPATH-before-custom-search-pa.patch
@@ -1,14 +1,14 @@
-From 8145cf9d74ea777207e8c07193dc88bc547575a0 Mon Sep 17 00:00:00 2001
+From 1855d31a212cfac8011ac015b1c7a3d799d5e850 Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Tue, 7 Nov 2023 17:20:06 +0000
-Subject: [PATCH] modules.paths: try PYTHONPATH before custom search paths
+Subject: [PATCH 1/2] modules.paths: try PYTHONPATH before custom search paths
 
 ---
- modules/paths.py | 14 ++++++++++++++
- 1 file changed, 14 insertions(+)
+ modules/paths.py | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
 
 diff --git a/modules/paths.py b/modules/paths.py
-index 25052339..b14cd734 100644
+index 25052339..2af454f1 100644
 --- a/modules/paths.py
 +++ b/modules/paths.py
 @@ -1,5 +1,7 @@
@@ -19,11 +19,10 @@ index 25052339..b14cd734 100644
  from modules.paths_internal import models_path, script_path, data_path, extensions_dir, extensions_builtin_dir  # noqa: F401
  
  import modules.safe  # noqa: F401
-@@ -43,6 +45,18 @@ path_dirs = [
+@@ -43,9 +45,29 @@ path_dirs = [
      (os.path.join(sd_path, '../k-diffusion'), 'k_diffusion/sampling.py', 'k_diffusion', ["atstart"]),
  ]
  
-+
 +def find_dist_info(name):
 +    name = name.replace("-", "_")
 +    for path in sys.path:
@@ -31,13 +30,25 @@ index 25052339..b14cd734 100644
 +            return match
 +
 +
-+REQUIRED_DISTS = [ "sgm", "stable_diffusion", "blip", "k_diffusion" ]
-+if all(find_dist_info(name) is not None for name in REQUIRED_DISTS):
-+    path_dirs = []
-+
  paths = {}
  
++REQUIRED_DISTS = [ "ldm", "sgm", "stable_diffusion", "blip", "k_diffusion" ]
++
++for dist, (_, _, what, _) in zip(REQUIRED_DISTS, path_dirs):
++    m = find_dist_info(dist)
++    if not m:
++        continue
++
++    # Let's pretend we put `configs` inside the packages
++    paths[what] = m.parent / dist
++
  for d, must_exist, what, options in path_dirs:
++    if what in paths:
++        continue
++
+     must_exist_path = os.path.abspath(os.path.join(script_path, d, must_exist))
+     if not os.path.exists(must_exist_path):
+         print(f"Warning: {what} not found at path {must_exist_path}", file=sys.stderr)
 -- 
 2.42.0
 

--- a/python-packages/by-name/st/stable-diffusion-webui/0001-modules.paths-try-PYTHONPATH-before-custom-search-pa.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0001-modules.paths-try-PYTHONPATH-before-custom-search-pa.patch
@@ -1,0 +1,43 @@
+From 8145cf9d74ea777207e8c07193dc88bc547575a0 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Tue, 7 Nov 2023 17:20:06 +0000
+Subject: [PATCH] modules.paths: try PYTHONPATH before custom search paths
+
+---
+ modules/paths.py | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/modules/paths.py b/modules/paths.py
+index 25052339..b14cd734 100644
+--- a/modules/paths.py
++++ b/modules/paths.py
+@@ -1,5 +1,7 @@
+ import os
+ import sys
++from pathlib import Path
++
+ from modules.paths_internal import models_path, script_path, data_path, extensions_dir, extensions_builtin_dir  # noqa: F401
+ 
+ import modules.safe  # noqa: F401
+@@ -43,6 +45,18 @@ path_dirs = [
+     (os.path.join(sd_path, '../k-diffusion'), 'k_diffusion/sampling.py', 'k_diffusion', ["atstart"]),
+ ]
+ 
++
++def find_dist_info(name):
++    name = name.replace("-", "_")
++    for path in sys.path:
++        for match in Path(path).glob(f"{name}-*.dist-info"):
++            return match
++
++
++REQUIRED_DISTS = [ "sgm", "stable_diffusion", "blip", "k_diffusion" ]
++if all(find_dist_info(name) is not None for name in REQUIRED_DISTS):
++    path_dirs = []
++
+ paths = {}
+ 
+ for d, must_exist, what, options in path_dirs:
+-- 
+2.42.0
+

--- a/python-packages/by-name/st/stable-diffusion-webui/0001-modules.paths-try-PYTHONPATH-before-custom-search-pa.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0001-modules.paths-try-PYTHONPATH-before-custom-search-pa.patch
@@ -1,7 +1,7 @@
 From 1855d31a212cfac8011ac015b1c7a3d799d5e850 Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Tue, 7 Nov 2023 17:20:06 +0000
-Subject: [PATCH 1/5] modules.paths: try PYTHONPATH before custom search paths
+Subject: [PATCH 1/8] modules.paths: try PYTHONPATH before custom search paths
 
 ---
  modules/paths.py | 22 ++++++++++++++++++++++

--- a/python-packages/by-name/st/stable-diffusion-webui/0002-launch_utils-do-not-git-clone.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0002-launch_utils-do-not-git-clone.patch
@@ -1,7 +1,7 @@
 From 6b07a78e916bc56195022417958d882f61642482 Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Fri, 17 Nov 2023 03:17:51 +0000
-Subject: [PATCH 2/5] launch_utils: do not git clone
+Subject: [PATCH 2/8] launch_utils: do not git clone
 
 ---
  modules/launch_utils.py | 1 +

--- a/python-packages/by-name/st/stable-diffusion-webui/0002-launch_utils-do-not-git-clone.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0002-launch_utils-do-not-git-clone.patch
@@ -1,7 +1,7 @@
 From 6b07a78e916bc56195022417958d882f61642482 Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Fri, 17 Nov 2023 03:17:51 +0000
-Subject: [PATCH 2/2] launch_utils: do not git clone
+Subject: [PATCH 2/5] launch_utils: do not git clone
 
 ---
  modules/launch_utils.py | 1 +

--- a/python-packages/by-name/st/stable-diffusion-webui/0002-launch_utils-do-not-git-clone.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0002-launch_utils-do-not-git-clone.patch
@@ -1,0 +1,24 @@
+From 6b07a78e916bc56195022417958d882f61642482 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Fri, 17 Nov 2023 03:17:51 +0000
+Subject: [PATCH 2/2] launch_utils: do not git clone
+
+---
+ modules/launch_utils.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/modules/launch_utils.py b/modules/launch_utils.py
+index 6e54d063..b39008b0 100644
+--- a/modules/launch_utils.py
++++ b/modules/launch_utils.py
+@@ -308,6 +308,7 @@ def requirements_met(requirements_file):
+ 
+ 
+ def prepare_environment():
++    return
+     torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu118")
+     torch_command = os.environ.get('TORCH_COMMAND', f"pip install torch==2.0.1 torchvision==0.15.2 --extra-index-url {torch_index_url}")
+     requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
+-- 
+2.42.0
+

--- a/python-packages/by-name/st/stable-diffusion-webui/0003-paths_internal-just-use-the-relative-paths.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0003-paths_internal-just-use-the-relative-paths.patch
@@ -1,7 +1,7 @@
 From 92cae133ff87020ab46fe8c294d6c3f014bf8197 Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Sat, 18 Nov 2023 01:02:37 +0000
-Subject: [PATCH 3/5] paths_internal: just use the relative paths...
+Subject: [PATCH 3/8] paths_internal: just use the relative paths...
 
 ---
  modules/paths_internal.py | 8 ++++----

--- a/python-packages/by-name/st/stable-diffusion-webui/0003-paths_internal-just-use-the-relative-paths.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0003-paths_internal-just-use-the-relative-paths.patch
@@ -1,0 +1,40 @@
+From 92cae133ff87020ab46fe8c294d6c3f014bf8197 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Sat, 18 Nov 2023 01:02:37 +0000
+Subject: [PATCH 3/5] paths_internal: just use the relative paths...
+
+---
+ modules/paths_internal.py | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/modules/paths_internal.py b/modules/paths_internal.py
+index 005a9b0a..7a62c6ff 100644
+--- a/modules/paths_internal.py
++++ b/modules/paths_internal.py
+@@ -13,19 +13,19 @@ script_path = os.path.dirname(modules_path)
+ 
+ sd_configs_path = os.path.join(script_path, "configs")
+ sd_default_config = os.path.join(sd_configs_path, "v1-inference.yaml")
+-sd_model_file = os.path.join(script_path, 'model.ckpt')
++sd_model_file = 'model.ckpt'
+ default_sd_model_file = sd_model_file
+ 
+ # Parse the --data-dir flag first so we can use it as a base for our other argument default values
+ parser_pre = argparse.ArgumentParser(add_help=False)
+-parser_pre.add_argument("--data-dir", type=str, default=os.path.dirname(modules_path), help="base path where all user data is stored", )
++parser_pre.add_argument("--data-dir", type=str, default="sd_webui_data", help="base path where all user data is stored", )
+ cmd_opts_pre = parser_pre.parse_known_args()[0]
+ 
+ data_path = cmd_opts_pre.data_dir
+ 
+ models_path = os.path.join(data_path, "models")
+ extensions_dir = os.path.join(data_path, "extensions")
+-extensions_builtin_dir = os.path.join(script_path, "extensions-builtin")
+-config_states_dir = os.path.join(script_path, "config_states")
++extensions_builtin_dir = "extensions-builtin"
++config_states_dir = "config_states"
+ 
+ roboto_ttf_file = os.path.join(modules_path, 'Roboto-Regular.ttf')
+-- 
+2.42.0
+

--- a/python-packages/by-name/st/stable-diffusion-webui/0004-sd_disable_initialization-the-https-huggingface.co-N.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0004-sd_disable_initialization-the-https-huggingface.co-N.patch
@@ -1,7 +1,7 @@
 From 2ab01d1b64f1833c25783368b219219f7f3faaca Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Sat, 18 Nov 2023 01:14:28 +0000
-Subject: [PATCH 4/5] sd_disable_initialization: the
+Subject: [PATCH 4/8] sd_disable_initialization: the
  https://huggingface.co/None/resolve/main/config.json issue
 
 ---

--- a/python-packages/by-name/st/stable-diffusion-webui/0004-sd_disable_initialization-the-https-huggingface.co-N.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0004-sd_disable_initialization-the-https-huggingface.co-N.patch
@@ -1,0 +1,26 @@
+From 2ab01d1b64f1833c25783368b219219f7f3faaca Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Sat, 18 Nov 2023 01:14:28 +0000
+Subject: [PATCH 4/5] sd_disable_initialization: the
+ https://huggingface.co/None/resolve/main/config.json issue
+
+---
+ modules/sd_disable_initialization.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/modules/sd_disable_initialization.py b/modules/sd_disable_initialization.py
+index 8863107a..9b9f9110 100644
+--- a/modules/sd_disable_initialization.py
++++ b/modules/sd_disable_initialization.py
+@@ -65,7 +65,7 @@ class DisableInitialization(ReplaceHelper):
+             return self.create_model_and_transforms(*args, pretrained=None, **kwargs)
+ 
+         def CLIPTextModel_from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs):
+-            res = self.CLIPTextModel_from_pretrained(None, *model_args, config=pretrained_model_name_or_path, state_dict={}, **kwargs)
++            res = self.CLIPTextModel_from_pretrained(pretrained_model_name_or_path, *model_args, config=pretrained_model_name_or_path, state_dict={}, **kwargs)
+             res.name_or_path = pretrained_model_name_or_path
+             return res
+ 
+-- 
+2.42.0
+

--- a/python-packages/by-name/st/stable-diffusion-webui/0005-git-don-t-use-it.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0005-git-don-t-use-it.patch
@@ -1,0 +1,139 @@
+From 31603fc8c0dbdca1ddb43fabbcc342b0419ace1b Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Sat, 18 Nov 2023 01:43:35 +0000
+Subject: [PATCH 5/5] git: don't use it
+
+---
+ modules/config_states.py | 12 +++++++++++-
+ modules/extensions.py    |  8 ++++++++
+ modules/launch_utils.py  |  4 +++-
+ modules/ui_extensions.py |  7 ++++++-
+ 4 files changed, 28 insertions(+), 3 deletions(-)
+
+diff --git a/modules/config_states.py b/modules/config_states.py
+index b766aef1..9a21f235 100644
+--- a/modules/config_states.py
++++ b/modules/config_states.py
+@@ -8,7 +8,7 @@ import time
+ import tqdm
+ 
+ from datetime import datetime
+-import git
++git = None
+ 
+ from modules import shared, extensions, errors
+ from modules.paths_internal import script_path, config_states_dir
+@@ -47,6 +47,14 @@ def list_config_states():
+ 
+ 
+ def get_webui_config():
++    print("Ignoring get_webui_config()")
++    return {
++        "remote": "origin",
++        "commit_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
++        "commit_date": "Thu, 01 Jan 1970 00:00:00 +0000",
++        "branch": "master",
++    }
++
+     webui_repo = None
+ 
+     try:
+@@ -114,6 +122,8 @@ def get_config():
+ 
+ 
+ def restore_webui_config(config):
++    print("Ignoring restore_webui_config()")
++    return
+     print("* Restoring webui state...")
+ 
+     if "webui" not in config:
+diff --git a/modules/extensions.py b/modules/extensions.py
+index bf9a1878..5e2add9f 100644
+--- a/modules/extensions.py
++++ b/modules/extensions.py
+@@ -64,6 +64,9 @@ class Extension:
+         self.status = 'unknown' if self.status == '' else self.status
+ 
+     def do_read_info_from_repo(self):
++        print(f"{__name__}: do_read_info_from_repo: Preventing an attempt to read .git in {self.path}")
++        self.remote = None
++        return
+         repo = None
+         try:
+             if os.path.exists(os.path.join(self.path, ".git")):
+@@ -103,6 +106,9 @@ class Extension:
+         return res
+ 
+     def check_updates(self):
++        self.can_update = False
++        self.status = "fixed"
++        return
+         repo = Repo(self.path)
+         for fetch in repo.remote().fetch(dry_run=True):
+             if fetch.flags != fetch.HEAD_UPTODATE:
+@@ -125,6 +131,8 @@ class Extension:
+         self.status = "latest"
+ 
+     def fetch_and_reset_hard(self, commit='origin'):
++        self.have_info_from_repo = False
++        return
+         repo = Repo(self.path)
+         # Fix: `error: Your local changes to the following files would be overwritten by merge`,
+         # because WSL2 Docker set 755 file permissions instead of 644, this results to the error.
+diff --git a/modules/launch_utils.py b/modules/launch_utils.py
+index b39008b0..8dca8fa9 100644
+--- a/modules/launch_utils.py
++++ b/modules/launch_utils.py
+@@ -19,7 +19,7 @@ args, _ = cmd_args.parser.parse_known_args()
+ logging_config.setup_logging(args.loglevel)
+ 
+ python = sys.executable
+-git = os.environ.get('GIT', "git")
++git = os.environ.get('GIT', "WE_DONT_USE_GIT_AT_RUNTIME")
+ index_url = os.environ.get('INDEX_URL', "")
+ dir_repos = "repositories"
+ 
+@@ -221,6 +221,8 @@ def version_check(commit):
+ 
+ def run_extension_installer(extension_dir):
+     path_installer = os.path.join(extension_dir, "install.py")
++    print(f"{__name__}: Preventing a `python {path_installer}`")
++    return
+     if not os.path.isfile(path_installer):
+         return
+ 
+diff --git a/modules/ui_extensions.py b/modules/ui_extensions.py
+index 2e8c1d6d..767e83a6 100644
+--- a/modules/ui_extensions.py
++++ b/modules/ui_extensions.py
+@@ -4,7 +4,7 @@ import threading
+ import time
+ from datetime import datetime, timezone
+ 
+-import git
++git = None
+ 
+ import gradio as gr
+ import html
+@@ -338,6 +338,9 @@ def normalize_git_url(url):
+ def install_extension_from_url(dirname, url, branch_name=None):
+     check_access()
+ 
++    print(f"Ignoring install_extension_from_url({repr(dirname)}, {repr(url)}, branch_name={repr(branch_name)})")
++    return [extension_table(), html.escape(f"Not installing anything, because at this point we shouldn't")]
++
+     if isinstance(dirname, str):
+         dirname = dirname.strip()
+     if isinstance(url, str):
+@@ -394,6 +397,8 @@ def install_extension_from_url(dirname, url, branch_name=None):
+ 
+ 
+ def install_extension_from_index(url, hide_tags, sort_column, filter_text):
++    print(f"Ignoring install_extension_from_index({repr(url)}, {repr(hide_tags)}, {sort_column=}, filter_text={repr(filter_text)})")
++    return "", "", "", ""
+     ext_table, message = install_extension_from_url(None, url)
+ 
+     code, _ = refresh_available_extensions_from_data(hide_tags, sort_column, filter_text)
+-- 
+2.42.0
+

--- a/python-packages/by-name/st/stable-diffusion-webui/0005-git-don-t-use-it.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0005-git-don-t-use-it.patch
@@ -1,17 +1,17 @@
-From 31603fc8c0dbdca1ddb43fabbcc342b0419ace1b Mon Sep 17 00:00:00 2001
+From 812eb34866ca3a70462f472d68d61ca046eea9f9 Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Sat, 18 Nov 2023 01:43:35 +0000
-Subject: [PATCH 5/5] git: don't use it
+Subject: [PATCH 5/8] git: don't use it
 
 ---
  modules/config_states.py | 12 +++++++++++-
- modules/extensions.py    |  8 ++++++++
+ modules/extensions.py    |  9 +++++++++
  modules/launch_utils.py  |  4 +++-
- modules/ui_extensions.py |  7 ++++++-
- 4 files changed, 28 insertions(+), 3 deletions(-)
+ modules/ui_extensions.py | 11 ++++++++---
+ 4 files changed, 31 insertions(+), 5 deletions(-)
 
 diff --git a/modules/config_states.py b/modules/config_states.py
-index b766aef1..9a21f235 100644
+index b766aef1..77770aa9 100644
 --- a/modules/config_states.py
 +++ b/modules/config_states.py
 @@ -8,7 +8,7 @@ import time
@@ -31,7 +31,7 @@ index b766aef1..9a21f235 100644
 +    return {
 +        "remote": "origin",
 +        "commit_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-+        "commit_date": "Thu, 01 Jan 1970 00:00:00 +0000",
++        "commit_date": 0,
 +        "branch": "master",
 +    }
 +
@@ -48,20 +48,21 @@ index b766aef1..9a21f235 100644
  
      if "webui" not in config:
 diff --git a/modules/extensions.py b/modules/extensions.py
-index bf9a1878..5e2add9f 100644
+index bf9a1878..49046918 100644
 --- a/modules/extensions.py
 +++ b/modules/extensions.py
-@@ -64,6 +64,9 @@ class Extension:
+@@ -64,6 +64,10 @@ class Extension:
          self.status = 'unknown' if self.status == '' else self.status
  
      def do_read_info_from_repo(self):
 +        print(f"{__name__}: do_read_info_from_repo: Preventing an attempt to read .git in {self.path}")
 +        self.remote = None
++        self.have_info_from_repo = True
 +        return
          repo = None
          try:
              if os.path.exists(os.path.join(self.path, ".git")):
-@@ -103,6 +106,9 @@ class Extension:
+@@ -103,6 +107,9 @@ class Extension:
          return res
  
      def check_updates(self):
@@ -71,7 +72,7 @@ index bf9a1878..5e2add9f 100644
          repo = Repo(self.path)
          for fetch in repo.remote().fetch(dry_run=True):
              if fetch.flags != fetch.HEAD_UPTODATE:
-@@ -125,6 +131,8 @@ class Extension:
+@@ -125,6 +132,8 @@ class Extension:
          self.status = "latest"
  
      def fetch_and_reset_hard(self, commit='origin'):
@@ -103,7 +104,7 @@ index b39008b0..8dca8fa9 100644
          return
  
 diff --git a/modules/ui_extensions.py b/modules/ui_extensions.py
-index 2e8c1d6d..767e83a6 100644
+index 2e8c1d6d..54af84b1 100644
 --- a/modules/ui_extensions.py
 +++ b/modules/ui_extensions.py
 @@ -4,7 +4,7 @@ import threading
@@ -115,6 +116,21 @@ index 2e8c1d6d..767e83a6 100644
  
  import gradio as gr
  import html
+@@ -198,12 +198,12 @@ def update_config_states_table(state_name):
+ 
+     config_name = config_state.get("name", "Config")
+     created_date = time.asctime(time.gmtime(config_state["created_at"]))
+-    filepath = config_state.get("filepath", "<unknown>")
++    filepath = config_state.get("filepath", "<unknown filepath>")
+ 
+     try:
+         webui_remote = config_state["webui"]["remote"] or ""
+         webui_branch = config_state["webui"]["branch"]
+-        webui_commit_hash = config_state["webui"]["commit_hash"] or "<unknown>"
++        webui_commit_hash = config_state["webui"]["commit_hash"] or "<unknown hash>"
+         webui_commit_date = config_state["webui"]["commit_date"]
+         if webui_commit_date:
+             webui_commit_date = time.asctime(time.gmtime(webui_commit_date))
 @@ -338,6 +338,9 @@ def normalize_git_url(url):
  def install_extension_from_url(dirname, url, branch_name=None):
      check_access()

--- a/python-packages/by-name/st/stable-diffusion-webui/0006-gradio-serve-module-files-undconditionally.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0006-gradio-serve-module-files-undconditionally.patch
@@ -1,0 +1,26 @@
+From 26b45c10a4bf7150d0ea81970ee4d07774493901 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Sat, 18 Nov 2023 04:12:13 +0000
+Subject: [PATCH 6/8] gradio: serve module files undconditionally
+
+In case we override --data-dir
+---
+ modules/cmd_args.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/modules/cmd_args.py b/modules/cmd_args.py
+index aab62286..763b2d04 100644
+--- a/modules/cmd_args.py
++++ b/modules/cmd_args.py
+@@ -83,7 +83,7 @@ parser.add_argument("--gradio-auth", type=str, help='set gradio authentication l
+ parser.add_argument("--gradio-auth-path", type=str, help='set gradio authentication file path ex. "/path/to/auth/file" same auth format as --gradio-auth', default=None)
+ parser.add_argument("--gradio-img2img-tool", type=str, help='does not do anything')
+ parser.add_argument("--gradio-inpaint-tool", type=str, help="does not do anything")
+-parser.add_argument("--gradio-allowed-path", action='append', help="add path to gradio's allowed_paths, make it possible to serve files from it", default=[data_path])
++parser.add_argument("--gradio-allowed-path", action='append', help="add path to gradio's allowed_paths, make it possible to serve files from it", default=[data_path, os.path.dirname(os.path.dirname(__file__))])
+ parser.add_argument("--opt-channelslast", action='store_true', help="change memory type for stable diffusion to channels last")
+ parser.add_argument("--styles-file", type=str, help="filename to use for styles", default=os.path.join(data_path, 'styles.csv'))
+ parser.add_argument("--autolaunch", action='store_true', help="open the webui URL in the system's default browser upon launch", default=False)
+-- 
+2.42.0
+

--- a/python-packages/by-name/st/stable-diffusion-webui/0007-gradio-just-use-abspaths.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0007-gradio-just-use-abspaths.patch
@@ -1,0 +1,35 @@
+From 9a6a70953aacb4c9a07d664a37adaa8b30340c59 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Sat, 18 Nov 2023 04:35:37 +0000
+Subject: [PATCH 7/8] gradio: just use abspaths,
+
+...because the way gradio serves static files appears broken
+---
+ modules/ui_gradio_extensions.py | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/modules/ui_gradio_extensions.py b/modules/ui_gradio_extensions.py
+index b824b113..c3dd5b0e 100644
+--- a/modules/ui_gradio_extensions.py
++++ b/modules/ui_gradio_extensions.py
+@@ -1,15 +1,13 @@
+ import os
+ import gradio as gr
++from pathlib import Path
+ 
+ from modules import localization, shared, scripts
+ from modules.paths import script_path, data_path
+ 
+ 
+ def webpath(fn):
+-    if fn.startswith(script_path):
+-        web_path = os.path.relpath(fn, script_path).replace('\\', '/')
+-    else:
+-        web_path = os.path.abspath(fn)
++    web_path = Path(fn).resolve().as_posix()
+ 
+     return f'file={web_path}?{os.path.getmtime(fn)}'
+ 
+-- 
+2.42.0
+

--- a/python-packages/by-name/st/stable-diffusion-webui/0008-patch-out-the-sys.path-tampering.patch
+++ b/python-packages/by-name/st/stable-diffusion-webui/0008-patch-out-the-sys.path-tampering.patch
@@ -1,0 +1,72 @@
+From e358055ec5957cc0458b406b67e917d902def4db Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Sat, 18 Nov 2023 04:41:43 +0000
+Subject: [PATCH 8/8] patch out the sys.path tampering
+
+---
+ modules/paths.py   | 13 ++++++++-----
+ modules/scripts.py |  6 ++++--
+ 2 files changed, 12 insertions(+), 7 deletions(-)
+
+diff --git a/modules/paths.py b/modules/paths.py
+index 2af454f1..ceabc0f3 100644
+--- a/modules/paths.py
++++ b/modules/paths.py
+@@ -23,7 +23,7 @@ def mute_sdxl_imports():
+ 
+ 
+ # data_path = cmd_opts_pre.data
+-sys.path.insert(0, script_path)
++# sys.path.insert(0, script_path)
+ 
+ # search for directory of stable diffusion in following places
+ sd_path = None
+@@ -74,14 +74,17 @@ for d, must_exist, what, options in path_dirs:
+     else:
+         d = os.path.abspath(d)
+         if "atstart" in options:
+-            sys.path.insert(0, d)
++            print(f"Prevented an attempt to tamper with sys.path: prepending {d}")
++            # sys.path.insert(0, d)
+         elif "sgm" in options:
+             # Stable Diffusion XL repo has scripts dir with __init__.py in it which ruins every extension's scripts dir, so we
+             # import sgm and remove it from sys.path so that when a script imports scripts.something, it doesbn't use sgm's scripts dir.
+ 
+-            sys.path.insert(0, d)
++            print(f"Prevented an attempt to tamper with sys.path: prepending {d}")
++            # sys.path.insert(0, d)
+             import sgm  # noqa: F401
+-            sys.path.pop(0)
++            # sys.path.pop(0)
+         else:
+-            sys.path.append(d)
++            print(f"Prevented an attempt to tamper with sys.path: prepending {d}")
++            # sys.path.append(d)
+         paths[what] = d
+diff --git a/modules/scripts.py b/modules/scripts.py
+index e8518ad0..8412406c 100644
+--- a/modules/scripts.py
++++ b/modules/scripts.py
+@@ -376,7 +376,8 @@ def load_scripts():
+     for scriptfile in sorted(scripts_list, key=lambda x: [orderby(x.basedir), x]):
+         try:
+             if scriptfile.basedir != paths.script_path:
+-                sys.path = [scriptfile.basedir] + sys.path
++                print(f"Prevented an attempt to tamper with sys.path: prepending {scriptfile.basedir}")
++                pass  # sys.path = [scriptfile.basedir] + sys.path
+             current_basedir = scriptfile.basedir
+ 
+             script_module = script_loading.load_module(scriptfile.path)
+@@ -386,7 +387,8 @@ def load_scripts():
+             errors.report(f"Error loading script: {scriptfile.filename}", exc_info=True)
+ 
+         finally:
+-            sys.path = syspath
++            # By the way syspath has been a reference to sys.path this whole time
++            pass  # sys.path = syspath
+             current_basedir = paths.script_path
+             timer.startup_timer.record(scriptfile.filename)
+ 
+-- 
+2.42.0
+

--- a/python-packages/by-name/st/stable-diffusion-webui/package.nix
+++ b/python-packages/by-name/st/stable-diffusion-webui/package.nix
@@ -137,7 +137,7 @@ buildPythonPackage rec {
     mkdir -p $out/bin/
     cat << EOF > $out/bin/sd-webui
     #!${stdenv.shell}
-    ${lib.getExe python} -m accelerate.commands.accelerate_cli launch $out/bin/._sd-webui-launch-wrapped $@
+    ${lib.getExe python} -m accelerate.commands.accelerate_cli launch $out/bin/._sd-webui-launch-wrapped \$@
     EOF
     chmod +x $out/bin/sd-webui
   '';

--- a/python-packages/by-name/st/stable-diffusion-webui/package.nix
+++ b/python-packages/by-name/st/stable-diffusion-webui/package.nix
@@ -67,6 +67,11 @@ buildPythonPackage rec {
     ./0003-paths_internal-just-use-the-relative-paths.patch
     ./0004-sd_disable_initialization-the-https-huggingface.co-N.patch
     ./0005-git-don-t-use-it.patch
+    ./0006-gradio-serve-module-files-undconditionally.patch
+    ./0007-gradio-just-use-abspaths.patch
+
+    # https://github.com/python-rope/rope/pull/732#issuecomment-1817386694
+    # ./0008-patch-out-the-sys.path-tampering.patch
   ];
 
   postPatch = ''
@@ -98,7 +103,15 @@ buildPythonPackage rec {
         "'modules.shared'" \
         "'sd_webui.modules.shared'"
 
-    mv *.js *.json *.css configs sd_webui/
+    mv \
+      *.js \
+      *.json \
+      *.css \
+      configs \
+      html \
+      javascript \
+      textual_inversion_templates \
+      sd_webui/
 
     substituteInPlace sd_webui/extensions_builtin/LDSR/sd_hijack_ddpm_v1.py \
       --replace \

--- a/python-packages/by-name/st/stable-diffusion-webui/package.nix
+++ b/python-packages/by-name/st/stable-diffusion-webui/package.nix
@@ -164,6 +164,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/AUTOMATIC1111/stable-diffusion-webui";
     changelog = "https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/${src.rev}/CHANGELOG.md";
     license = licenses.agpl3Only;
+    mainProgram = "sd-webui";
     maintainers = with maintainers; [ ];
   };
 }

--- a/python-packages/by-name/st/stable-diffusion-webui/package.nix
+++ b/python-packages/by-name/st/stable-diffusion-webui/package.nix
@@ -80,8 +80,16 @@ buildPythonPackage rec {
     prefix-python-modules . --prefix sd_webui
 
     # Until https://github.com/python-rope/rope/issues/731
-    sed -i -e '0,/import sd_webui.webui/{/import sd_webui.webui/d;}' \
+    sed -i \
+      -e '0,/import sd_webui.webui/{/import sd_webui.webui/d;}' \
+      -e 's/\([[:space:]]*\)def prepare_environment():/\1def prepare_environment():\n\1    return/' \
       sd_webui/modules/launch_utils.py
+
+    # Rope doesn't detect when people write module names as strings
+    substituteInPlace sd_webui/modules/shared_items.py \
+      --replace \
+        "'modules.shared'" \
+        "'sd_webui.modules.shared'"
 
     cp $pyprojectToml pyproject.toml
   '';

--- a/python-packages/by-name/st/stable-diffusion-webui/package.nix
+++ b/python-packages/by-name/st/stable-diffusion-webui/package.nix
@@ -78,6 +78,11 @@ buildPythonPackage rec {
         "possible_sd_paths = sys.path + ["
 
     prefix-python-modules . --prefix sd_webui
+
+    # Until https://github.com/python-rope/rope/issues/731
+    sed -i -e '0,/import sd_webui.webui/{/import sd_webui.webui/d;}' \
+      sd_webui/modules/launch_utils.py
+
     cp $pyprojectToml pyproject.toml
   '';
 
@@ -138,7 +143,7 @@ buildPythonPackage rec {
   '';
 
   # Circular imports...
-  # pythonImportsCheck = [ "sd_webui.launch" ];
+  pythonImportsCheck = [ "sd_webui.launch" ];
 
   postFixup = ''
     buildPythonPath "$out $pythonPath"

--- a/python-packages/by-name/st/stable-diffusion-webui/package.nix
+++ b/python-packages/by-name/st/stable-diffusion-webui/package.nix
@@ -62,6 +62,7 @@ buildPythonPackage rec {
 
   patches = [
     ./0001-modules.paths-try-PYTHONPATH-before-custom-search-pa.patch
+    ./0002-launch_utils-do-not-git-clone.patch
   ];
 
   postPatch = ''
@@ -77,12 +78,13 @@ buildPythonPackage rec {
         "possible_sd_paths = [" \
         "possible_sd_paths = sys.path + ["
 
+    touch localizations/__init__.py
+
     prefix-python-modules . --prefix sd_webui
 
     # Until https://github.com/python-rope/rope/issues/731
     sed -i \
       -e '0,/import sd_webui.webui/{/import sd_webui.webui/d;}' \
-      -e 's/\([[:space:]]*\)def prepare_environment():/\1def prepare_environment():\n\1    return/' \
       sd_webui/modules/launch_utils.py
 
     # Rope doesn't detect when people write module names as strings
@@ -90,6 +92,8 @@ buildPythonPackage rec {
       --replace \
         "'modules.shared'" \
         "'sd_webui.modules.shared'"
+
+    mv *.js *.json *.css configs sd_webui/
 
     cp $pyprojectToml pyproject.toml
   '';

--- a/python-packages/by-name/st/stable-diffusion-webui/package.nix
+++ b/python-packages/by-name/st/stable-diffusion-webui/package.nix
@@ -1,0 +1,156 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, stdenv
+, setuptools
+, wheel
+, accelerate
+, basicsr
+, blendmodes
+, clean-fid
+, codeformer
+, einops
+, fastapi
+, gfpgan
+, gitpython
+, gradio
+, huggingface-hub
+, inflection
+, jsonmerge
+, k-diffusion
+, kornia
+, lark
+, makeWrapper
+, numpy
+, omegaconf
+, open-clip-torch
+, piexif
+, pillow
+, prefix-python-modules
+, psutil
+, python
+, pytorch-lightning
+, realesrgan
+, requests
+, resize-right
+, safetensors
+, salesforce-blip
+, scikit-image
+, stability-ai-generative-models
+, stability-ai-sd
+, timm
+, tomesd
+, torch
+, torchdiffeq
+, torchsde
+, transformers
+}:
+
+buildPythonPackage rec {
+  pname = "stable-diffusion-webui";
+  version = "1.6.0";
+  pyproject = true;
+  pyprojectToml = ./pyproject.toml;
+
+
+  src = fetchFromGitHub {
+    owner = "AUTOMATIC1111";
+    repo = "stable-diffusion-webui";
+    rev = "v${version}";
+    hash = "sha256-V16VkOq0+wea4zbfeKBLAQBth022ZkpG8lh0p9u4txs=";
+  };
+
+  patches = [
+    ./0001-modules.paths-try-PYTHONPATH-before-custom-search-pa.patch
+  ];
+
+  postPatch = ''
+    mv extensions-builtin extensions_builtin
+    find -iname '*.py' -exec sed -i \
+      -e 's/extensions-builtin/extensions_builtin/g' \
+      -e 's/^\([[:space:]]*\)import launch/\1import modules.launch_utils as launch/g' \
+      '{}' \
+      '+'
+
+    substituteInPlace modules/paths.py \
+      --replace \
+        "possible_sd_paths = [" \
+        "possible_sd_paths = sys.path + ["
+
+    prefix-python-modules . --prefix sd_webui
+    cp $pyprojectToml pyproject.toml
+  '';
+
+  nativeBuildInputs = [
+    makeWrapper
+    prefix-python-modules
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    accelerate
+    basicsr
+    blendmodes
+    clean-fid
+    codeformer
+    einops
+    fastapi
+    gfpgan
+    gitpython
+    gradio
+    huggingface-hub
+    inflection
+    jsonmerge
+    k-diffusion
+    kornia
+    lark
+    numpy
+    omegaconf
+    open-clip-torch
+    piexif
+    pillow
+    psutil
+    pytorch-lightning
+    realesrgan
+    requests
+    resize-right
+    safetensors
+    salesforce-blip
+    scikit-image
+    stability-ai-generative-models
+    stability-ai-sd
+    timm
+    tomesd
+    torch
+    torchdiffeq
+    torchsde
+    transformers
+  ];
+
+  postInstall = ''
+    mkdir -p $out/bin/
+    cat << EOF > $out/bin/sd-webui
+    #!${stdenv.shell}
+    ${lib.getExe python} -m accelerate.commands.accelerate_cli launch $out/bin/._sd-webui-launch-wrapped $@
+    EOF
+    chmod +x $out/bin/sd-webui
+  '';
+
+  # Circular imports...
+  # pythonImportsCheck = [ "sd_webui.launch" ];
+
+  postFixup = ''
+    buildPythonPath "$out $pythonPath"
+    wrapProgram $out/bin/sd-webui \
+      --prefix PYTHONPATH : "$program_PYTHONPATH"
+  '';
+
+  meta = with lib; {
+    description = "Stable Diffusion web UI";
+    homepage = "https://github.com/AUTOMATIC1111/stable-diffusion-webui";
+    changelog = "https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/python-packages/by-name/st/stable-diffusion-webui/pyproject.toml
+++ b/python-packages/by-name/st/stable-diffusion-webui/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [ "setuptools" ]
+
+[project]
+name = "stable-diffusion-webui"
+version = "2023.11.6"
+
+[project.scripts]
+_sd-webui-launch = "sd_webui.launch:main"
+
+[tool.setuptools.packages.find]
+include = [ "sd_webui*" ]

--- a/python-packages/by-name/st/stable-diffusion-webui/pyproject.toml
+++ b/python-packages/by-name/st/stable-diffusion-webui/pyproject.toml
@@ -15,6 +15,9 @@ include-package-data = true
 [tool.setuptools.package-data]
 sd_webui = [ "*.js", "*.css", "*.json"]
 "sd_webui.configs" = [ "*.yaml" ]
+"sd_webui.html" = [ "*.html" ]
+"sd_webui.javascript" = [ "*.js" ]
+"sd_webui.textual_inversion_templates" = [ "*.txt" ]
 
 [tool.setuptools.packages.find]
 include = [ "sd_webui*" ]

--- a/python-packages/by-name/st/stable-diffusion-webui/pyproject.toml
+++ b/python-packages/by-name/st/stable-diffusion-webui/pyproject.toml
@@ -9,5 +9,12 @@ version = "2023.11.6"
 [project.scripts]
 _sd-webui-launch = "sd_webui.launch:main"
 
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-data]
+sd_webui = [ "*.js", "*.css", "*.json"]
+"sd_webui.configs" = [ "*.yaml" ]
+
 [tool.setuptools.packages.find]
 include = [ "sd_webui*" ]

--- a/python-packages/by-name/to/tomesd/package.nix
+++ b/python-packages/by-name/to/tomesd/package.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, torch
+}:
+
+buildPythonPackage rec {
+  pname = "tomesd";
+  version = "0.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "dbolya";
+    repo = "tomesd";
+    rev = "v${version}";
+    hash = "sha256-U3LN6KmQx/ulepFxjWgYHJl5g8j1U3HIGunpjcZBcos=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    torch
+  ];
+
+  pythonImportsCheck = [ "tomesd" ];
+
+  meta = with lib; {
+    description = "Speed up Stable Diffusion with this one simple trick";
+    homepage = "https://github.com/dbolya/tomesd";
+    changelog = "https://github.com/dbolya/tomesd/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/python-packages/by-name/to/torchdata/package.nix
+++ b/python-packages/by-name/to/torchdata/package.nix
@@ -1,0 +1,73 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cmake
+, ninja
+, setuptools
+, aws-sdk-cpp
+, pybind11
+, requests
+, torch
+, urllib3
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "torchdata";
+  version = "0.7.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "data";
+    rev = "v${version}";
+    hash = "sha256-7TCmTYUhi3rH+bF7Ht5Sj470iFMOMpAZ7NV0o5/uLkQ=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace \
+        'subprocess.check_call(["git", "submodule"' \
+        '# subprocess.check_call(["git", "submodule"' \
+      --replace \
+        'sys.exit(1)' \
+        'pass'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    setuptools
+    wheel
+  ];
+
+  buildInputs = [
+    aws-sdk-cpp
+    pybind11
+  ];
+
+  propagatedBuildInputs = [
+    requests
+    urllib3
+    torch # FIXME: upstream puts it in native deps
+  ];
+
+  cmakeFlags = [
+    "-GNinja"
+    "-DUSE_SYSTEM_PYBIND11=ON"
+    "-DUSE_SYSTEM_AWS_SDK_CPP=ON"
+  ];
+
+  postConfigure = ''
+    cd ..
+  '';
+
+  pythonImportsCheck = [ "torchdata" ];
+
+  meta = with lib; {
+    description = "A PyTorch repo for data loading and utilities to be shared by the PyTorch domain libraries";
+    homepage = "https://github.com/pytorch/data";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/python-packages/by-name/we/webdataset/package.nix
+++ b/python-packages/by-name/we/webdataset/package.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, braceexpand
+, numpy
+, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "webdataset";
+  version = "0.2.73";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "webdataset";
+    repo = "webdataset";
+    rev = version;
+    hash = "sha256-Lk84rIDWDhYKwDXjW5OQ7dSFm4kSmVrIiIxK6AXKlUU=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    braceexpand
+    numpy
+    pyyaml
+  ];
+
+  pythonImportsCheck = [ "webdataset" ];
+
+  meta = with lib; {
+    description = "A high-performance Python-based I/O system for large (and small) deep learning problems, with strong support for PyTorch";
+    homepage = "https://github.com/webdataset/webdataset";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+  };
+}


### PR DESCRIPTION
MWE for:

- `nix run github:SomeoneSerge/pkgs/feat/comfyui#pkgsCuda.some-pkgs.some-pkgs-py.stable-diffusion-webui`
- ...

The `comfy-ui` still seems broken (various `expected X got NoneType` errors at runtime that I don't feel motivated to look into)

Note that making this work has taken a bit of patching, and these patches are going probably going to diverge from the mainline soon. The "relocatability" issues do have to be addressed upstream instead. Note that the extensions- and updates-related features were disabled in order to reduce the number of side-effects. Note that the application still downloads and loads arbitrary unauthenticated pickle files, which means arbitrary code execution.